### PR TITLE
#8 - allow blank targets with dom sanitization

### DIFF
--- a/src/main/js/bundles/dn_welcome/WelcomeWidget.ts.vue
+++ b/src/main/js/bundles/dn_welcome/WelcomeWidget.ts.vue
@@ -108,7 +108,12 @@
         },
         computed: {
             sanitizedInfoText() {
-                return DOMPurify.sanitize(this.infoText, {USE_PROFILES: {html: true}});
+                DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+                    if (node.tagName === 'A' && node.getAttribute('target') === '_blank' || node.getAttribute('target') === 'blank') {
+                        node.setAttribute('rel', 'noopener noreferrer');
+                    }
+                });
+                return DOMPurify.sanitize(this.infoText, {USE_PROFILES: {html: true}, ADD_ATTR: ['target']});
             }
         }
     });


### PR DESCRIPTION
target attributes are allowed. However, if they are used, ensure the 'rel' attribute is added with 'noopener' and 'noreferrer'